### PR TITLE
Updating to a newer version of monlog 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 build/
 vendor/
 composer.phar
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     }],
     "description": "VWO server side sdk",
     "require": {
-        "monolog/monolog": "1.0.*",
+        "monolog/monolog": "^1.0",
         "ramsey/uuid": "^3.8",
         "justinrainbow/json-schema": "^5.2"
     },


### PR DESCRIPTION
Having it locked at 1.0.* is quite strict, ^1.0 is allowing it to use all 1.x versions of Monolog.

The items we use for Monolog is not affected as part of this.