### PR TITLE
Add support for Monolog 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     }],
     "description": "VWO server side sdk",
     "require": {
-        "monolog/monolog": "^2.0",
+        "monolog/monolog": "^1.0 || ^2.0",
         "ramsey/uuid": "^3.8",
         "justinrainbow/json-schema": "^5.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     }],
     "description": "VWO server side sdk",
     "require": {
-        "monolog/monolog": "^1.0",
+        "monolog/monolog": "^2.0",
         "ramsey/uuid": "^3.8",
         "justinrainbow/json-schema": "^5.2"
     },


### PR DESCRIPTION
This affects PHP 7.2 codebases and above.
Monolog 1.x does not work with PHP 7.2 codebases.